### PR TITLE
Note about UseLogin being deprecated

### DIFF
--- a/docs/guidelines/openssh.md
+++ b/docs/guidelines/openssh.md
@@ -130,6 +130,7 @@ AuthenticationMethods publickey,keyboard-interactive:pam
 KbdInteractiveAuthentication yes
 UsePAM yes
 # Ensure /bin/login is not used so that it cannot bypass PAM settings for sshd.
+# Note, this option is no longer needed as of OpenSSH 7.4 as support for UseLogin has been removed
 UseLogin no
 ```
 


### PR DESCRIPTION
See also https://www.openssh.com/txt/release-7.4
Eventually, we should deprecate all docs regarding openssh < 7.x as it's becoming more and more rare