### PR TITLE
Remove logout hint

### DIFF
--- a/docs/guidelines/iam/openid_connect.md
+++ b/docs/guidelines/iam/openid_connect.md
@@ -67,8 +67,9 @@ For that reason, it is important that the web application (RP) respects the foll
     -   This ensures that access is revoked within *15 minutes* in the event that the user's account is disabled by the OpenID Connect Provider (OP).
     -   This issues a new ID token, with new attributes if they have changed.
     -   This may also renew the ID token expiration time.
-    -   This is generally done with the parameter `prompt=none` while calling the OpenID Connect `authorize` endpoint. See also [specifications](https://openid.net/specs/openid-connect-implicit-1_0.html#RequestParameters).
--   The web application (RP) can **optionally** provide a `logout` URL, which the OpenID Connect Provider (OP) can call to indicate if a user has logged out (so that the web application immediately know when to log the user out as well).
+    -   This is generally done with the parameter `prompt=none` while calling the OpenID Connect `authorize` endpoint. See also [specifications](https://openid.net/specs/openid-connect-implicit-1_0.html#RequestParameters).\
+    - This can also be done in the back-end to avoid a round-trip in the user-agent (user's web browser).
+
 
 ## Other important security considerations
 


### PR DESCRIPTION
Because while its true, it's confusing for users and the global logout is an industry-wide issue
also Add a hint about back-end triggered session checks