### PR TITLE
Remove IRC

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,20 +22,18 @@ Infosec assists Mozillians in defining and operating security controls to ensure
 
 For security incidents, file a bug in Bugzilla under the product/component [investigation](https://bugzilla.mozilla.org/enter_bug.cgi?product=Enterprise%20Information%20Security&component=Investigation) or [incidents](https://bugzilla.mozilla.org/enter_bug.cgi?product=Enterprise%20Information%20Security&component=Incident).
 
-Our IRC channel is [#infosec](irc://irc.mozilla.org/infosec) or [#security](irc://irc.mozilla.org/security) at irc.mozilla.org.
-
 ## Members
-  - Guillaume Destuynder [🐦](https://twitter.com/kangsterizer) [💻](https://github.com/gdestuynder/) *[:kang]*
-  - Gene Wood *[:gene]*
-  - April King *[:April]*
-  - Andrew Krug *[:andrew]*
-  - Justin Dow *[:jabba]*
-  - Jonathan Claudius *[:claudijd]*
-  - Caglar Ulucenk *[:Cag]*
-  - Tristan Weir *[:weir]*
-    - Alicia Smith *[:phrozyn]*
-    - Brandon Myers *[:pwnbus]*
-    - Lucius Bono *[:lucius]*
-    - Michal Purzynski *[:michal`]*
-    - Emma Rose *[:emrose]*
+  - Guillaume Destuynder [🐦](https://twitter.com/kangsterizer) [💻](https://github.com/gdestuynder/) *[@kang]*
+  - Gene Wood *[@gene]*
+  - April King *[@April]*
+  - Andrew Krug *[@andrew]*
+  - Justin Dow *[@jabba]*
+  - Jonathan Claudius *[@claudijd]*
+  - Caglar Ulucenk *[@Cag]*
+  - Tristan Weir *[@weir]*
+    - Alicia Smith *[@phrozyn]*
+    - Brandon Myers *[@pwnbus]*
+    - Lucius Bono *[@lucius]*
+    - Michal Purzynski *[@michał]*
+    - Emma Rose *[@emma]*
 


### PR DESCRIPTION
Take out references to our now-unmonitored IRC channel. Convert all IRC nicknames to Slack usernames