### PR TITLE
Update for gpg2 command changes

### DIFF
--- a/docs/guidelines/key_management.md
+++ b/docs/guidelines/key_management.md
@@ -74,7 +74,7 @@ See [OpenSSH](openssh "wikilink").
 ## PGP/GnuPG
 
 ```
-$ gpg --gen-key
+$ gpg --full-gen-key
 (1) RSA and RSA (default)
 [...]
 Your selection? 1


### PR DESCRIPTION
Now ``gpg --gen-key`` is the quick path, and only asks for id, then generates a 2048 bit key. To get the traditional key options, you need to use ``--full-gen-key``.