### PR TITLE
Pursue my anti-robots.txt crusade

### DIFF
--- a/docs/guidelines/web_security.md
+++ b/docs/guidelines/web_security.md
@@ -716,14 +716,16 @@ Referrer-Policy: no-referrer, strict-origin-when-cross-origin
 
 # robots.txt
 
-`robots.txt` is a text file placed within the root directory of a site that tells robots (such as indexers employed by search engines) how to behave, by instructing them not to index certain paths on the website. This is particularly useful for reducing load on your website, though disabling the indexing of automatically generated content. It can also be helpful for preventing the pollution of search results, for resources that don't benefit from being searchable.
+`robots.txt` is a text file placed within the root directory of a site that tells robots (such as indexers employed by search engines) how to behave, by instructing them not to crawl certain paths on the website. This is particularly useful for reducing load on your website, though disabling the crawling of automatically generated content. It can also be helpful for preventing the pollution of search results, for resources that don't benefit from being searchable.
 
-Sites may optionally use robots.txt, but should only use it for these purposes. It should not be used as a way to prevent the disclosure of private information or to hide portions of a website. Although this does prevent these sites from appearing in search engines, it does not prevent its discovery from attackers, as `robots.txt` is frequently used for reconnaisance.
+Sites may optionally use robots.txt, but should only use it for these purposes. It should not be used as a way to prevent the disclosure of private information or to hide portions of a website. Many search engines, like Google and Bing, will includes webpages in their search results, even if those results are blocked via robots.txt, if they know those pages exist (for example, if they're linked to). Furthermore, `robots.txt` is frequently used by attackers for reconnaisance.
+
+To properly prevent a resource from appearing in search results, encourage it to be crawled by *omitting* it from robots.txt, and by adding [`robots` meta tags and HTTP headers](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#Attributes).
 
 ## Examples
 
 ```sh
-# Stop all search engines from archiving this site
+# Stop all search engines from crawling this site
 User-agent: *
 Disallow: /
 ```
@@ -737,6 +739,7 @@ Disallow: /secret/admin-interface
 ## See Also
 
 - [About robots.txt](http://www.robotstxt.org/robotstxt.html)
+- [Robots Meta Tags](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta)
 
 # Subresource Integrity
 


### PR DESCRIPTION
Look, I get it, robots.txt was here first, but it's time to admit that Google and Bing disagree with us about what it means. It does *not* prevent a page from appearing in Google or Bing. It *only* prevents Google and Bing from crawling the page, but if those search engines want to index the page, they will know the URL and will put that in their index anyway. Sure, you could say they're greedy for links, or that they're literalists in their interepretation of robots.txt ("You said 'No robots, right?'"), but whatever they are, the fact remains: 

## Robots.txt does not, I repeat again, NOT prevent a page from being in search engines

Indeed, as indicated in these changes, if you want an item to get out of search engines, that page should *not* be in robots.txt, so that Google and Bing can *explicitly* crawl it. If you want to really go wild, you should also:

 - Include the page in sitemaps.xml (encouraging crawlers further)
 - Block your sitemaps.xml from being indexed (preventing the URL from being disclosed that way). I added this change to Django. 

And, when you change a page from being public to being private by way of the robots meta or HTTP tag, you should also:

 - Add it to robots.txt for a day so that it immediately gets removed
 - A day or so later, encourage Google and Bing to re-crawl the page so they pick up the new tags

Will I win this crusade and change the world's understanding of robots.txt? Time will tell. It appears that for every instance of this I fix, another ten developers are born. 

----------

Credentials: I run a public-facing website with about ten million court documents.