### PR TITLE
Updated links to new locations and https where possible.

### DIFF
--- a/docs/guidelines/assessing_security_risk.md
+++ b/docs/guidelines/assessing_security_risk.md
@@ -13,7 +13,7 @@ Mozilla's framework is inspired by [ISO 31000](https://www.iso.org/iso/home/stan
 
 It is recommended to read the [FAIR Introduction](https://web.archive.org/web/20141118061526/http://www.riskmanagementinsight.com/media/docs/FAIR_introduction.pdf)
 as an introduction to how risk is generally assessed, and get familiar with the terms. Note that we do not use the FAIR
-methodology, however, the concepts are well exposed in their documentation 
+methodology, however, the concepts are well exposed in their documentation
 
 # What is risk?
 Risk is commonly defined as: `risk = impact * likelihood`
@@ -95,10 +95,10 @@ criticality, risk, urgency, work-effort, etc. in a completely standardized way.
 
 # Reference documents
 
-- [Introduction to modern risk analysis](http://riskmanagementinsight.com/media/documents/FAIR_Introduction.pdf)
-- [ISO 31000](http://www.iso.org/iso/home/standards/iso31000.htm)
+- [Introduction to modern risk analysis](https://web.archive.org/web/20141118061526/http://www.riskmanagementinsight.com/media/docs/FAIR_introduction.pdf)
+- [ISO 31000](https://www.iso.org/iso-31000-risk-management.html)
 - [ISO 27001](https://en.wikipedia.org/wiki/ISO/IEC_27001)
 - [In
-  French - EBIOS method](http://www.ssi.gouv.fr/guide/ebios-2010-expression-des-besoins-et-identification-des-objectifs-de-securite/)
+  French - EBIOS method](https://www.ssi.gouv.fr/guide/ebios-2010-expression-des-besoins-et-identification-des-objectifs-de-securite/)
 - [SANS Critical Security Controls](https://www.sans.org/critical-security-controls/controls)
 - [Visualizations common in Risk Management](https://creately.com/blog/diagrams/risk-management-techniques/)

--- a/docs/guidelines/aws_security.md
+++ b/docs/guidelines/aws_security.md
@@ -22,7 +22,7 @@ The [root user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-user.ht
 
 ## Enable multi factor authentication (MFA) for the root user
 
-* How to : [Instructions](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_enable_virtual.html#enable-virt-mfa-for-root)
+* How to : [Instructions](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_enable_virtual.html#enable-virt-mfa-for-root)
 * Audited : True
 * Rationale
     - [MFA is an effective means of preventing unauthorized access](https://wiki.mozilla.org/Security/Fundamentals#mfa)

--- a/docs/guidelines/key_management.md
+++ b/docs/guidelines/key_management.md
@@ -122,4 +122,4 @@ keyid-format 0xlong
 
 Security Bits estimate the computational steps or operations (not machine instructions) required to solve a cryptographic problem (i.e. crack the key/hash). Of course, these do not factor in weaknesses in the algorithms which would reduce the effective amount of security bits and therefore is only used as an indicator of the width of the total (maximum) space to exhaust to ensuring finding the key.
 
-For a more detailed definition, see  <https://en.wikipedia.org/wiki/Key_size>, <https://en.wikipedia.org/wiki/Secure_Hash_Algorithm> and <http://www.cryptopp.com/wiki/Security_Level#Security_Bits>.
+For a more detailed definition, see  <https://en.wikipedia.org/wiki/Key_size>, <https://en.wikipedia.org/wiki/Secure_Hash_Algorithm> and <https://www.cryptopp.com/wiki/Security_Level#Security_Bits>.

--- a/docs/guidelines/risk/rapid_risk_assessment.md
+++ b/docs/guidelines/risk/rapid_risk_assessment.md
@@ -298,7 +298,7 @@ up and this is a great time to have a quick 5 minute chat about these.
 
 - <https://binary.protect.io/workcard.pdf>
 - <https://en.wikipedia.org/wiki/ISO_31000>
-- <http://www.riskmanagementinsight.com/media/docs/FAIR_introduction.pdf>
+- <https://web.archive.org/web/20141118061526/http://www.riskmanagementinsight.com/media/docs/FAIR_introduction.pdf>
 
 ## RRA Links
 

--- a/docs/guidelines/web_security.md
+++ b/docs/guidelines/web_security.md
@@ -452,7 +452,7 @@ Content-Security-Policy: default-src 'none'; frame-ancestors 'none'
 
 ## See Also
 
-- [An Introduction to Content Security Policy](http://www.html5rocks.com/en/tutorials/security/content-security-policy/)
+- [An Introduction to Content Security Policy](https://www.html5rocks.com/en/tutorials/security/content-security-policy/)
 - [Content Security Policy Level 2 Standard](https://www.w3.org/TR/CSP2/)
 - [Google CSP Evaluator](https://csp-evaluator.withgoogle.com/)
 - [Using the frame-ancestors directive to prevent framing](#x-frame-options)
@@ -478,7 +478,7 @@ Require subkeys include `name`, `description`, `bugs`, `participate` (particular
     },
     "participate": {
       "home": "https://wiki.mozilla.org/Webdev/GetInvolved/mozilla.org",
-      "docs": "http://bedrock.readthedocs.org/",
+      "docs": "https://bedrock.readthedocs.io/en/latest/",
       "mailing-list": "https://www.mozilla.org/about/forums/#dev-mozilla-org",
       "irc": "irc://irc.mozilla.org/#www",
       "irc-contacts": [
@@ -650,7 +650,7 @@ httpRequest.setRequestHeader('X-CSRF-Token', token); // add it as an X-CSRF-Toke
 ## See Also
 
 - [Wikipedia on CRSF Attacks and Prevention](https://en.wikipedia.org/wiki/Cross-site_request_forgery#Prevention)
-- [OWASP CSRF Prevention Cheat Sheet](https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet)
+- [OWASP CSRF Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html)
 
 # Referrer Policy
 
@@ -736,7 +736,7 @@ Disallow: /secret/admin-interface
 
 ## See Also
 
-- [About robots.txt](http://www.robotstxt.org/robotstxt.html)
+- [About robots.txt](https://www.robotstxt.org/robotstxt.html)
 
 # Subresource Integrity
 


### PR DESCRIPTION
`- <http://2016.video.sector.ca/video/189177390> (SecTor 2016 Introductory Presentation on Kubernetes security)` is a dead link. There are many presentations on Kubernetes security, at various levels. Could you please add an alternative?

I did not update `xmlns` and similar.