### PR TITLE
Removed link to Mozilla MIG.

### DIFF
--- a/docs/fundamentals/security_principles.md
+++ b/docs/fundamentals/security_principles.md
@@ -143,7 +143,6 @@ order to retrace actions after a security breach.
 -   Send logs off the account or system (e.g. AWS CloudTrail, system logs, etc.) outside of the account or system
     (different AWS account, MozDef, Papertrail, etc.)
 -   Detect and alert on anomalous changes.
--   Run [MIG](https://github.com/mozilla/mig/).
 
 ## Are you at risk?
 


### PR DESCRIPTION
The Github repository is archived, and there's a deprecation note on http://mozilla.github.io/mig/

I don't have experience with any of these tools (MIG is also listed). Perhaps there's an alternative among them?
https://linuxsecurity.expert/tools/grr-rapid-response/alternatives/