### PR TITLE
Update references to EIS, infosec and the associated Bugzilla product

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -72,10 +72,9 @@
         <section class="col col-3">
           <ul class="links-social">
             <li>
-              Enterprise Information Security:
+              Security:
               <ul>
                 <li class="wrap"><a href="https://twitter.com/mozillaSecurity">Twitter<span> (@mozillaSecurity)</span></a></li>
-                <li class="wrap"><a href="irc://irc.mozilla.org/infosec">IRC<span> (#infosec)</span></a></li>
               </ul>
             </li>
 

--- a/docs/contribute.json
+++ b/docs/contribute.json
@@ -1,16 +1,12 @@
 {
-    "name": "Infosec Guidelines for Mozilla",
-    "description": "Infosec assists Mozillians in defining and operating security controls to ensure that data at Mozilla is protected consistently.",
+    "name": "Security Guidelines for Mozilla",
+    "description": "Security Assurance and Security Operations assist Mozillians in defining and operating security controls to ensure that data at Mozilla is protected consistently.",
     "repository": {
         "url": "https://github.com/mozilla/infosec.mozilla.org",
         "license": "MPL2"
     },
     "participate": {
         "home": "https://infosec.mozilla.org/",
-        "irc": "irc://irc.mozilla.org/#infosec",
-        "irc-contacts": [
-            "kang"
-        ],
         "docs": "https://github.com/mozilla/infosec.mozilla.org/blob/master/README.md"
     },
     "bugs": {

--- a/docs/fundamentals/rationales.md
+++ b/docs/fundamentals/rationales.md
@@ -8,7 +8,7 @@ description: Explains and justifies the use of specific controls, principles
 
 *The goal of this document is to detail the rationales behind why various technologies and processes are encouraged or discouraged.
 All Mozilla sites and deployment should follow the recommendations below.
-The Enterprise Information Security (Infosec) team maintains this document as a reference guide.*
+The Security Assurance and Security Operations teams maintain this document as a reference guide.*
 
 # Rationales
 

--- a/docs/fundamentals/security_principles.md
+++ b/docs/fundamentals/security_principles.md
@@ -9,7 +9,7 @@ description: Most important security principles to follow - the baseline
 *This document defines a set of security principles that all operational groups at Mozilla must follow. The principles
 are designed to reduce the exposure of our systems and services from attackers who could gain privileged access and
 compromise sensitive data.  [The Firefox Operations Security](https://wiki.mozilla.org/Security/FirefoxOperations) and
-the [Enterprise Information Security](https://infosec.mozilla.org/) teams maintain the list of principles, and work with
+the [Security](https://infosec.mozilla.org/) teams maintain the list of principles, and work with
 operational teams throughout Mozilla to ensure their implementation.*
 
 

--- a/docs/guidelines/iam/openid_connect.md
+++ b/docs/guidelines/iam/openid_connect.md
@@ -8,7 +8,7 @@ description: How to use OpenID Connect securely and make user’s session experi
 
 *The goal of this document is to help you understand the basics of how to securely implement [OpenID Connect (OIDC)](https://en.wikipedia.org/wiki/OpenID_Connect) when authenticating and authorizing users.
 All Mozilla sites and deployment should follow the recommendations below.
-The Enterprise Information Security (Infosec) team maintains this document as a reference guide.*
+The Security Assurance and Security Operations teams maintain this document as a reference guide.*
 
 **Just looking for code?** Reference configuration and code for implementing OIDC as described below [is also available](https://github.com/mozilla-iam/testrp.security.allizom.org).
 Additionally, Mozilla provides OIDC single sign on support for Mozilla properties and [access can be requested by following documentation here](https://mana.mozilla.org/wiki/display/SECURITY/SSO+Request+Form)

--- a/docs/guidelines/iam/saml.md
+++ b/docs/guidelines/iam/saml.md
@@ -8,7 +8,7 @@ description: How to use SAML securely and make user’s session experience bette
 
 *The goal of this document is to help understand the basics of how to securely implement [Security Assertion Markup Language (SAML)](https://en.wikipedia.org/wiki/SAML) when authenticating and authorizing users.
 All Mozilla sites and deployment should follow the recommendations below.
-The Enterprise Information Security (Infosec) team maintains this document as a reference guide.*
+The Security Assurance and Security Operations teams maintain this document as a reference guide.*
 
 **Just looking for code?** Reference configuration and code for implementing SAML as described below [is also available](https://github.com/mozilla-iam/testrp.security.allizom.org).
 Additionally, Mozilla provides SAML single sign on support for Mozilla properties and [access can be requested by following documentation here](https://mana.mozilla.org/wiki/display/SECURITY/SSO+Request+Form)

--- a/docs/guidelines/key_management.md
+++ b/docs/guidelines/key_management.md
@@ -8,7 +8,7 @@ description: Find out which algorithms are recommended, when to expire keys, etc
 
 *The goal of this document is to help operational teams with the handling and management of cryptographic material.
 All Mozilla sites and deployment should follow the recommendations below.
-The Enterprise Information Security (Infosec) team maintains this document as a reference guide for operational teams.*
+The Security Assurance and Security Operations teams maintain this document as a reference guide for operational teams.*
 
 # Data Definitions
 

--- a/docs/guidelines/kubernetes.md
+++ b/docs/guidelines/kubernetes.md
@@ -8,7 +8,7 @@ description: A high level guide of basic security needs for Kubernetes
 
 *The goal of this document is to help you understand the basics of how to securely implement [Kubernetes](https://kubernetes.io/docs/) at Mozilla.
 All Mozilla sites and deployment should follow the recommendations below.
-The Enterprise Information Security (Infosec) team maintains this document as a reference guide.*
+The Security Assurance and Security Operations teams maintain this document as a reference guide.*
 
 
 # Why Kubernetes?

--- a/docs/guidelines/openssh.md
+++ b/docs/guidelines/openssh.md
@@ -8,7 +8,7 @@ description: How to configure and use OpenSSH server and client securely
 
 *The goal of this document is to help operational teams with the configuration of OpenSSH server and client.
 All Mozilla sites and deployment should follow the recommendations below.
-The Enterprise Information Security (Infosec) team maintains this document as a reference guide.*
+The Security Assurance and Security Operations teams maintain this document as a reference guide.*
 
 
 # Only non-default settings are listed in this document
@@ -387,7 +387,7 @@ $ ssh -J ssh.mozilla.com myhost.private.scl3.mozilla.com
 $ ssh -J ssh.mozilla.com,ec2-instance.aws.net 10.0.0.3
 
 # Copy data from a host
-$ scp -oProxyJump=ssh.mozilla.com myhost.private.scl3.mozilla.com:/home/kang/testfile ./
+$ scp -oProxyJump=ssh.mozilla.com myhost.private.scl3.mozilla.com:/home/jdoe/testfile ./
 ```
 
 You can also add these lines to your `~/.ssh/config`

--- a/docs/guidelines/risk/rapid_risk_assessment.md
+++ b/docs/guidelines/risk/rapid_risk_assessment.md
@@ -64,7 +64,7 @@ The RRA risk table facilitates discovering the answers to these questions.
 
 # How-to: Request an RRA of your service
 
-To manually request an RRA, please [file a bug](https://bugzilla.mozilla.org/enter_bug.cgi?product=Enterprise%20Information%20Security&component=Rapid%20Risk%20Analysis) to our component. Please include basic information about the project, a diagram, any relevant links and 0-2 additional people to invite for the assessment.
+To manually request an RRA, please [file a bug](https://bugzilla.mozilla.org/enter_bug.cgi?product=Security+Assurance&component=Rapid%20Risk%20Analysis) to our component. Please include basic information about the project, a diagram, any relevant links and 0-2 additional people to invite for the assessment.
 
 
 # How-to: Attending and running RRAs
@@ -305,8 +305,8 @@ up and this is a great time to have a quick 5 minute chat about these.
 
 - [Current RRA requests](https://mzl.la/2c4a09F)
 - [New RRA
-  request](https://bugzilla.mozilla.org/enter_bug.cgi?product=Enterprise%20Information%20Security&component=Rapid%20Risk%20Analysis)
+  request](https://bugzilla.mozilla.org/enter_bug.cgi?product=Security+Assurance&component=Rapid%20Risk%20Analysis)
 - [New Vulnerability
-  Assessment](https://bugzilla.mozilla.org/enter_bug.cgi?product=Enterprise%20Information%20Security&component=Vulnerability%20Assessment)
+  Assessment](https://bugzilla.mozilla.org/enter_bug.cgi?product=Security+Assurance&component=Vulnerability%20Assessment)
 - [RRA Support code for the Google Docs template](https://github.com/mozilla/infosec.mozilla.org/blob/master/misc/RRACodeMaster.js)
 - [RRA Parsing code (convert to spreadsheet/db) for the Google Docs template](https://github.com/mozilla/infosec.mozilla.org/blob/master/misc/RRA2Spreadsheet.js)

--- a/docs/guidelines/web_security.md
+++ b/docs/guidelines/web_security.md
@@ -7,7 +7,7 @@ description: What headers, setup, etc. should you follow for your web site?
 ---
 
 *The goal of this document is to help operational teams with creating secure web applications. All Mozilla sites and deployments are expected to follow the recommendations below. Use of these recommendations by the public is strongly encouraged.
-The Enterprise Information Security (Infosec) team maintains this document as a reference guide.*
+The Security Assurance and Security Operations teams maintain this document as a reference guide.*
 
 # Table of Contents
 1. [Cheat Sheet](#web-security-cheat-sheet)

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,5 +19,3 @@ Security Assurance and Security Operations assist Mozillians in defining and ope
 
 ## Contact
 [Open a ticket with Security Assurance](https://bugzilla.mozilla.org/enter_bug.cgi?product=Security+Assurance&component=General). For confidential information, encrypt using [our public PGP key](https://gpg.mozilla.org/pks/lookup?op=get&search=0x85D77543B3D624B63CEA9E6DBC17301B491B3F21). Our full fingerprint is `0x85D77543B3D624B63CEA9E6DBC17301B491B3F21`
-
-For security incidents, file a [Jira issue](https://jira.mozilla.com/secure/CreateIssueDetails!init.jspa?pid=10300).

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,8 @@
 layout: default
 ---
 
-# Enterprise Information Security
-Infosec assists Mozillians in defining and operating security controls to ensure that data at Mozilla is protected consistently across the organization.
+# Security Assurance and Security Operations
+Security Assurance and Security Operations assist Mozillians in defining and operating security controls to ensure that data at Mozilla is protected consistently across the organization.
 
 - we help you define the risks around your services and data
 - we help projects design and implement security controls
@@ -18,6 +18,6 @@ Infosec assists Mozillians in defining and operating security controls to ensure
 {% include_relative fundamentals/index.md %}
 
 ## Contact
-[Open a ticket with us](https://bugzilla.mozilla.org/enter_bug.cgi?product=Enterprise+Information+Security&component=General). For confidential information, encrypt using [our public PGP key](https://gpg.mozilla.org/pks/lookup?op=get&search=0x85D77543B3D624B63CEA9E6DBC17301B491B3F21). Our full fingerprint is `0x85D77543B3D624B63CEA9E6DBC17301B491B3F21`
+[Open a ticket with Security Assurance](https://bugzilla.mozilla.org/enter_bug.cgi?product=Security+Assurance&component=General). For confidential information, encrypt using [our public PGP key](https://gpg.mozilla.org/pks/lookup?op=get&search=0x85D77543B3D624B63CEA9E6DBC17301B491B3F21). Our full fingerprint is `0x85D77543B3D624B63CEA9E6DBC17301B491B3F21`
 
-For security incidents, file a bug in Bugzilla under the product/component [investigation](https://bugzilla.mozilla.org/enter_bug.cgi?product=Enterprise%20Information%20Security&component=Investigation) or [incidents](https://bugzilla.mozilla.org/enter_bug.cgi?product=Enterprise%20Information%20Security&component=Incident).
+For security incidents, file a [Jira issue](https://jira.mozilla.com/secure/CreateIssueDetails!init.jspa?pid=10300).


### PR DESCRIPTION
With the 2020 reorganization of security teams, there is no long an
Enterprise Information Security (EIS) / Infosec team. These responsibilities
now lie with the Security Assurance team and the Security Operations team (secops)