### PR TITLE
Remove HPKP, which is obsolete

### DIFF
--- a/docs/guidelines/web_security.md
+++ b/docs/guidelines/web_security.md
@@ -15,8 +15,7 @@ The Security Assurance and Security Operations teams maintain this document as a
     1. [HTTPS](#https)
     2. [HTTP Strict Transport Security](#http-strict-transport-security)
     3. [HTTP Redirections](#http-redirections)
-    4. [HTTP Public Key Pinning](#http-public-key-pinning)
-    5. [Resource Loading](#resource-loading)
+    4. [Resource Loading](#resource-loading)
 3. [Content Security Policy](#content-security-policy)
 4. [contribute.json](#contributejson)
 5. [Cookies](#cookies)
@@ -51,14 +50,6 @@ The Security Assurance and Security Operations teams maintain this document as a
 <td  data-sort-value="0"></td>
 <td> Mandatory</td>
 <td> Sites should use HTTPS (or other secure protocols) for all communications</td>
-</tr>
-<tr>
-<td data-sort-value="2" > <a href="#http-public-key-pinning"><span >Public Key Pinning</span></a></td>
-<td data-sort-value="1" > <span class="risk-low">LOW</span></td>
-<td data-sort-value="4" > <span class="risk-maximum">MAXIMUM</span></td>
-<td  data-sort-value="99"> --</td>
-<td> Mandatory for maximum risk sites only</td>
-<td> Not recommended for most sites</td>
 </tr>
 <tr>
 <td data-sort-value="3" > <a href="#http-redirections"><span >Redirections from HTTP</span></a>
@@ -329,32 +320,6 @@ server {
   Redirect permanent / https://site.mozilla.org/
 </VirtualHost>
 ```
-
-## HTTP Public Key Pinning
-
-[Maximum risk](/guidelines/risk/standard_levels#standard-risk-levels-definition-and-nomenclature) sites must enable the use of HTTP Public Key Pinning (HPKP). HPKP instructs a user agent to bind a site to specific root certificate authority, intermediate certificate authority, or end-entity public key. This prevents certificate authorities from issuing unauthorized certificates for a given domain that would nevertheless be trusted by the browsers. These fraudulent certificates would allow an active attacker to MitM and impersonate a website, intercepting credentials and other sensitive data.
-
-Due to the risk of knocking yourself off the internet, HPKP must be implemented with extreme care. This includes having backup key pins, testing on a non-production domain, testing with `Public-Key-Pins-Report-Only` and then finally doing initial testing with a very short-lived `max-age` directive. Because of the risk of creating a self-denial-of-service and the very low risk of a fraudulent certificate being issued, it is <em>not recommended</em> for the majority websites to implement HPKP.
-
-### Directives
-
-- `max-age:` number of seconds the user agent will enforce the key pins and require a site to use a cert that satisfies them
-- `includeSubDomains:` whether user agents should pin all subdomains to the same pins
-
-Unlike with HSTS, what to set `max-age` is highly individualized to a given site. A longer value is more secure, but screwing up your key pins will result in your site being unavailable for a longer period of time. Recommended values fall between 15 and 120 days.
-
-### Examples
-
-```sh
-# Pin to DigiCert, Let's Encrypt, and the local public-key, including subdomains, for 15 days
-Public-Key-Pins: max-age=1296000; includeSubDomains; pin-sha256="WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=";
- pin-sha256="YLh1dUR9y6Kja30RrAn7JKnbQG/uEtLMkBgFF2Fuihg="; pin-sha256="P0NdsLTMT6LSwXLuSEHNlvg4WxtWb5rIJhfZMyeXUE0="
-```
-
-### See Also
-
-- [About Public Key Pinning](https://noncombatant.org/2015/05/01/about-http-public-key-pinning/)
-- [The HPKP Toolset](https://scotthelme.co.uk/hpkp-toolset/) - helpful tools for generating key pins
 
 ## Resource Loading
 
@@ -856,6 +821,7 @@ X-XSS-Protection: 1; mode=block
 
 | Date           | Editor | Changes                                                          |
 |----------------|--------|------------------------------------------------------------------|
+| March, 2022    | timmc  | Remove HPKP section                                              |
 | July, 2018     | April  | Link to CORS for Developers                                      |
 | April, 2018    | April  | Added SameSite cookies and syntax highlighting                   |
 | June, 2017     | April  | Moved cookie prefixes to no longer be experimental               |


### PR DESCRIPTION
I'm not aware of any browser that still recognizes public key pinning.