### PR TITLE
Add Mozilla SSL Configuration Generator to `docs/tools/index.md`

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -6,4 +6,5 @@
       {% endif %}
     {% endif %}
   {% endfor %}
+  <li><a href="https://ssl-config.mozilla.org/">SSL Configuration Generator</a></li>
 </ul>


### PR DESCRIPTION
Fixes #161 

Apologies if I misunderstood the comment in issue #161 and added this to the wrong location. Let me know if you'd like me to move this somewhere else.