### PR TITLE
Remove deprecated option UsePrivilegeSeparation

### DIFF
--- a/docs/guidelines/openssh.md
+++ b/docs/guidelines/openssh.md
@@ -53,10 +53,6 @@ Subsystem sftp  /usr/lib/ssh/sftp-server -f AUTHPRIV -l INFO
 # On other OSes, the user session id is not necessarily recorded at all kernel-side.
 # Using regular users in combination with /bin/su or /usr/bin/sudo ensure a clear audit track.
 PermitRootLogin No
-
-# Use kernel sandbox mechanisms where possible in unprivileged processes
-# Systrace on OpenBSD, Seccomp on Linux, seatbelt on MacOSX/Darwin, rlimit elsewhere.
-UsePrivilegeSeparation sandbox
 ```
 
 File: `/etc/ssh/moduli`


### PR DESCRIPTION
UsePrivilegeSeparation was deprecated in OpenSSH version 7.5.

Release notes available here:  
[https://www.openssh.com/txt/release-7.5
](https://www.openssh.com/txt/release-7.5
)

Relevant section from release notes:  
> Potentially-incompatible changes
> ================================
> 
> This release includes a number of changes that may affect existing
> configurations:
> 
>  * This release deprecates the sshd_config UsePrivilegeSeparation
>    option, thereby making privilege separation mandatory. Privilege
>    separation has been on by default for almost 15 years and
>    sandboxing has been on by default for almost the last five.