### PR TITLE
Replace link to internal template to public template

### DIFF
--- a/docs/guidelines/risk/rapid_risk_assessment.md
+++ b/docs/guidelines/risk/rapid_risk_assessment.md
@@ -129,7 +129,7 @@ This is a guided example of how to run an initial RRA. You will:
   - Ensure no previous RRA exist; if it does, just enhance the current RRA document
   - Create a copy of the RRA template in the RRA Google Drive directory.
     - Mozilla employees can make a copy of the template with this [redirect](https://public.us-west-2.infosec.mozilla.org/web-tools/redirect-to-new-RRA-doc.html)
-    - Everyone can view the [RRA template](https://docs.google.com/document/d/1QMRdBLlQYqbn5lMmrOIBwS55Yh9fIYNp4dO3-HMyiyk/edit)
+    - Everyone can view a copy of the [RRA template](https://docs.google.com/document/d/1uD-wofmkXBz5BVq49JQQqC3DnE77vwOPDSbHdWIve9s/edit)
   - Invite 1 or 2 members (product/service owners, lead engineers, etc.) related
     to the service with a bit of technical knowledge.
   - Ensure the invitees attempt to bring a data flow diagram and have an understanding of the data the service stores or


### PR DESCRIPTION
Recently, changes were made in the Mozilla Google Workspace that caused the Shared Drive which the RRA template lives within to override the share settings making the previously public RRA template, no longer public.

This replaces that link to a new copy of the RRA template which is not in the Shared Drive and which is available publicly.

Note : There is now a risk that we update the internal RRA template (in the Template Gallery) but forget to upload the public copy.

Fixes #167