### PR TITLE
Disallow Encrypt-And-MAC MAC algorithms in modern config

### DIFF
--- a/docs/guidelines/openssh.md
+++ b/docs/guidelines/openssh.md
@@ -35,7 +35,7 @@ KexAlgorithms curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384
 
 Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
 
-MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com
+MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com
 
 # Password based logins are disabled - only public key based logins are allowed.
 AuthenticationMethods publickey


### PR DESCRIPTION
The current version of the "Modern configuration" includes the MAC schemes 

```
hmac-sha2-512
hmac-sha2-256
umac-128@openssh.com
```

Those MAC schemes use SSH's classic *Encrypt-and-MAC* methodology, which is well known to have cryptographic flaws (e.g., see [this paper by Bellare et.al](https://eprint.iacr.org/2002/078.pdf) or https://moxie.org/2011/12/13/the-cryptographic-doom-principle.html).

Usage of those algorithms is also [flagged by ssh-audit](https://www.ssh-audit.com/hardening_guides.html):

```
[...]
# message authentication code algorithms
(mac) hmac-sha2-512-etm@openssh.com         -- [info] available since OpenSSH 6.2
(mac) hmac-sha2-256-etm@openssh.com         -- [info] available since OpenSSH 6.2
(mac) umac-128-etm@openssh.com              -- [info] available since OpenSSH 6.2
(mac) hmac-sha2-512                         -- [warn] using encrypt-and-MAC mode
                                            `- [info] available since OpenSSH 5.9, Dropbear SSH 2013.56
(mac) hmac-sha2-256                         -- [warn] using encrypt-and-MAC mode
                                            `- [info] available since OpenSSH 5.9, Dropbear SSH 2013.56
(mac) umac-128@openssh.com                  -- [warn] using encrypt-and-MAC mode
                                            `- [info] available since OpenSSH 6.2
[...]
```

I would therefore suggest to remove the algorithms mentioned from the recommendation.